### PR TITLE
.

### DIFF
--- a/Client/src/features/chat/api/chatQueries.ts
+++ b/Client/src/features/chat/api/chatQueries.ts
@@ -66,12 +66,15 @@ export function useChatMessages(
     options,
   }: {
     limit?: number;
-    options?: UseInfiniteQueryOptions<
-      ChatMessagesResponse,
-      unknown,
-      ChatMessagesResponse,
-      ChatMessagesResponse,
-      ReturnType<typeof chatQueryKeys.messages>
+    options?: Omit<
+      UseInfiniteQueryOptions<
+        ChatMessagesResponse,
+        unknown,
+        InfiniteData<ChatMessagesResponse>,
+        ChatMessagesResponse,
+        ReturnType<typeof chatQueryKeys.messages>
+      >,
+      "queryKey" | "initialPageParam" | "getNextPageParam" | "queryFn"
     >;
   } = {}
 ) {
@@ -82,7 +85,7 @@ export function useChatMessages(
     queryFn: ({ pageParam }) =>
       fetchChatMessages(groupId, {
         limit,
-        beforeId: pageParam,
+        beforeId: pageParam as string | undefined,
       }),
     getNextPageParam: (lastPage) =>
       lastPage.hasMore


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines `useChatMessages` typing and casts `beforeId` to ensure correct React Query types and prevent overriding core options.
> 
> - **Client chat queries (`Client/src/features/chat/api/chatQueries.ts`)**
>   - **`useChatMessages`**:
>     - Narrow `options` type using `Omit<UseInfiniteQueryOptions<...>>` to exclude `queryKey`, `initialPageParam`, `getNextPageParam`, `queryFn`.
>     - Correct generics to use `InfiniteData<ChatMessagesResponse>` for `select` result type.
>     - Explicitly cast `beforeId` from `pageParam` to `string | undefined`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6bee9c98b5846e037fac76606c90be5b4228cbc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->